### PR TITLE
Maintenance

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ go:
 - 1.13.x
 
 install:
-- go get github.com/onsi/ginkgo/ginkgo
+- go install github.com/onsi/ginkgo/ginkgo
 
 script: ginkgo -r -randomizeSuites -randomizeAllSpecs -keepGoing -race -cover -trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 
 go:
-- "1.12.x"
-
-env:
-- GO111MODULE=on
+- 1.13.x
 
 install:
 - go get github.com/onsi/ginkgo/ginkgo

--- a/README.md
+++ b/README.md
@@ -10,19 +10,20 @@ Ciphertext is stored in memory and can be retrieved with the correct AES key.
 
 ## Get
 
-_This module requires Go 1.11 or greater._
+_This module requires Go 1.13 or greater._
 
 Download into GOPATH:
 
 ```bash
 go get github.com/jamesjoshuahill/secret
-export GO111MODULE=on
+cd "$(go env GOPATH)/src/github.com/jamesjoshuahill/secret"
 ```
 
 or elsewhere:
 
 ```bash
 git clone https://github.com/jamesjoshuahill/secret.git
+cd secret
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd secret
 Run the tests using the [Ginkgo](https://onsi.github.io/ginkgo/) test runner:
 
 ```bash
-go get github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/ginkgo
 ginkgo -r -race
 ```
 

--- a/aes/decrypt_test.go
+++ b/aes/decrypt_test.go
@@ -2,11 +2,11 @@ package aes_test
 
 import (
 	xaes "crypto/aes"
+	"errors"
 
 	"github.com/jamesjoshuahill/secret/aes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"golang.org/x/xerrors"
 )
 
 var _ = Describe("Decrypt", func() {
@@ -36,7 +36,7 @@ var _ = Describe("Decrypt", func() {
 	It("fails when the key is invalid", func() {
 		_, err := aes.Decrypt(aes.Secret{Key: ""})
 		Expect(err).To(HaveOccurred())
-		Expect(xerrors.Is(err, xaes.KeySizeError(0))).To(BeTrue())
+		Expect(errors.Is(err, xaes.KeySizeError(0))).To(BeTrue())
 	})
 
 	It("fails when the nonce is invalid", func() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jamesjoshuahill/secret
 
-go 1.12
+go 1.13
 
 require (
 	github.com/gorilla/mux v1.7.0
@@ -8,5 +8,4 @@ require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc // indirect
-	golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373
 )

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc h1:4gbWbmmPFp4ySWICouJl6emP0
 golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373 h1:PPwnA7z1Pjf7XYaBP9GL1VAMZmcIWyFz7QCMSIIa3Bg=
-golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/pkg/client/retreive_test.go
+++ b/pkg/client/retreive_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/jamesjoshuahill/secret/pkg/client"
-	"golang.org/x/xerrors"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -54,7 +53,7 @@ var _ = Describe("Retrieve", func() {
 
 		Expect(err).To(HaveOccurred())
 		unerr := &client.UnexpectedError{}
-		Expect(xerrors.As(err, unerr)).To(BeTrue())
+		Expect(errors.As(err, unerr)).To(BeTrue())
 		Expect(unerr.StatusCode).To(Equal(http.StatusInternalServerError))
 		Expect(unerr.Message).To(Equal("fake error"))
 	})
@@ -69,7 +68,7 @@ var _ = Describe("Retrieve", func() {
 
 		Expect(err).To(HaveOccurred())
 		unerr := &client.UnexpectedError{}
-		Expect(xerrors.As(err, unerr)).To(BeTrue())
+		Expect(errors.As(err, unerr)).To(BeTrue())
 		Expect(unerr.StatusCode).To(Equal(http.StatusInternalServerError))
 	})
 
@@ -82,7 +81,7 @@ var _ = Describe("Retrieve", func() {
 		_, err := c.Retrieve([]byte("some-id"), []byte("some-key"))
 
 		Expect(err).To(HaveOccurred())
-		Expect(xerrors.Is(err, client.ErrWrongIDOrKey)).To(BeTrue())
+		Expect(errors.Is(err, client.ErrWrongIDOrKey)).To(BeTrue())
 	})
 
 	It("fails when the response cannot be parsed", func() {

--- a/pkg/client/store_test.go
+++ b/pkg/client/store_test.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"golang.org/x/xerrors"
-
 	"github.com/jamesjoshuahill/secret/pkg/client"
 
 	. "github.com/onsi/ginkgo"
@@ -56,7 +54,7 @@ var _ = Describe("Store", func() {
 
 		Expect(err).To(HaveOccurred())
 		unerr := &client.UnexpectedError{}
-		Expect(xerrors.As(err, unerr)).To(BeTrue())
+		Expect(errors.As(err, unerr)).To(BeTrue())
 		Expect(unerr.StatusCode).To(Equal(http.StatusInternalServerError))
 		Expect(unerr.Message).To(Equal("fake error"))
 	})
@@ -71,7 +69,7 @@ var _ = Describe("Store", func() {
 
 		Expect(err).To(HaveOccurred())
 		unerr := &client.UnexpectedError{}
-		Expect(xerrors.As(err, unerr)).To(BeTrue())
+		Expect(errors.As(err, unerr)).To(BeTrue())
 		Expect(unerr.StatusCode).To(Equal(http.StatusInternalServerError))
 	})
 
@@ -84,7 +82,7 @@ var _ = Describe("Store", func() {
 		_, err := c.Store([]byte("some-id"), []byte("some-payload"))
 
 		Expect(err).To(HaveOccurred())
-		Expect(xerrors.Is(err, client.ErrAlreadyExists)).To(BeTrue())
+		Expect(errors.Is(err, client.ErrAlreadyExists)).To(BeTrue())
 	})
 
 	It("fails when the response cannot be parsed", func() {


### PR DESCRIPTION
# Why

The project failed to build because of the `golang.org/x/xerrors` dependency, so let's update to Go 1.13 and remove the dependency.

# What

- [x] Update to Go 1.13 and use standard library `errors` package
- [x] Install ginkgo CLI pinned in go.mod
